### PR TITLE
update node version for publishing step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ deploy:
   on:
     tags: true
     repo: test-editor/web-messaging-service
-    node: "6"
+    node: "9"


### PR DESCRIPTION
publishing 1.3.0 failed because of node version problems:
"Skipping a deployment with the npm provider because this is not on the required runtime"